### PR TITLE
Fix bug in preview header controls when svg has path fill style

### DIFF
--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -85,6 +85,10 @@ button {
   cursor: default;
 }
 
+.preview-header-controls svg path { 
+  fill: none; 
+}
+
 .toggle-dark-bg-wrapper {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Header control svg are affected when svg has path fill style:

<img width="1095" height="467" alt="bug-path-fill" src="https://github.com/user-attachments/assets/8232ee0b-4069-4aca-bf90-0c80e97b3649" />

Forcing none fill fix it:

`styles.css`

```css
.preview-header-controls svg path { 
  fill: none; 
}
```