### PR TITLE
Add support for Django HTML templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "onLanguage:typescriptreact",
     "onLanguage:svelte",
     "onLanguage:vue",
+    "onLanguage:django-html",
     "onLanguage:liquid"
   ],
   "categories": [

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -18,6 +18,7 @@ export const SUPPORTED_LANGUAGES = [
   'astro',
   'ejs',
   'erb',
+  'django-html',
   'html',
   'javascript',
   'javascriptreact',


### PR DESCRIPTION
Adds `django-html` to SUPPORTED_LANGUAGES and activationEvents so that hover preview and SVG optimization work inside Django template files.