### PR TITLE
Add previews for SVG symbol and use sprites

### DIFF
--- a/src/svgGutterPreview.ts
+++ b/src/svgGutterPreview.ts
@@ -15,7 +15,12 @@
  */
 
 import * as vscode from 'vscode'
-import { convertJsxToSvg } from './svgTransform'
+import {
+  collectSvgPreviewCandidates,
+  findSvgPreviewAtOffset,
+  svgToDataUri,
+  type SvgPreviewOptions
+} from './svgPreview'
 
 interface SvgCacheEntry {
   dataUri: string
@@ -27,6 +32,17 @@ interface HoverCommandArgs {
   uri: string
   start: number
   length: number
+}
+
+function getPreviewOptions (languageId: string, minSize: number): SvgPreviewOptions {
+  const isDarkTheme = vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark ||
+    vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.HighContrast
+
+  return {
+    useCamelCase: ['javascriptreact', 'typescriptreact'].includes(languageId),
+    contrastColor: isDarkTheme ? '#ffffff' : '#000000',
+    minSize
+  }
 }
 
 export class SvgHoverProvider implements vscode.HoverProvider {
@@ -45,92 +61,48 @@ export class SvgHoverProvider implements vscode.HoverProvider {
     }
 
     const text = document.getText()
-    const svgRegex = /<svg[\s\S]*?>[\s\S]*?<\/svg>/g
-    let match
+    const offset = document.offsetAt(position)
+    const candidate = findSvgPreviewAtOffset(text, offset, getPreviewOptions(document.languageId, 128))
 
-    while ((match = svgRegex.exec(text))) {
-      const startPos = document.positionAt(match.index)
-      const endPos = document.positionAt(match.index + match[0].length)
-      const range = new vscode.Range(startPos, endPos)
-
-      if (range.contains(position)) {
-        const originalSvg = match[0]
-        const sizeBytes = Buffer.byteLength(originalSvg, 'utf8')
-
-        // Check cache
-        const cacheKey = `${document.uri.toString()}:${match.index}:${originalSvg.length}`
-        const cached = this.cache.get(cacheKey)
-        const now = Date.now()
-
-        if (cached && (now - cached.timestamp) < this.cacheMaxAge) {
-          return this.createHoverFromCache(cached, range, document)
-        }
-
-        let svgContent = originalSvg
-        const options = {
-          useCamelCase: ['javascriptreact', 'typescriptreact'].includes(document.languageId)
-        }
-
-        // Convert JSX syntax to valid SVG
-        svgContent = convertJsxToSvg(svgContent, options)
-
-        // Add xmlns if missing (do this early so SVG is valid)
-        // Check ONLY inside the opening <svg ... > tag
-        const svgOpenTagMatch = svgContent.match(/<svg[^>]*>/i)
-        const hasXmlnsInRoot = svgOpenTagMatch && /xmlns\s*=\s*["']/.test(svgOpenTagMatch[0])
-        
-        if (!hasXmlnsInRoot) {
-          svgContent = svgContent.replace(/<svg/, '<svg xmlns="http://www.w3.org/2000/svg"')
-        }
-
-        // Replace currentColor based on theme
-        const isDarkTheme = vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark ||
-                            vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.HighContrast
-        const contrastColor = isDarkTheme ? '#ffffff' : '#000000'
-        svgContent = svgContent.replace(/currentColor/g, contrastColor)
-
-        // Extract stroke/fill from parent SVG and propagate to children
-        svgContent = this.propagateStrokeAndFill(svgContent)
-
-        // Ensure minimum size for visibility in hover
-        svgContent = this.ensureMinimumSize(svgContent, 128)
-
-        // Validate that the SVG is likely to be renderable. 
-        // If it still contains JSX-like braces (outside of <style> tags), 
-        // it's likely to show a broken image, so we'd rather show nothing.
-        const validationContent = svgContent.replace(/<style[\s\S]*?<\/style>/gi, '')
-        if (validationContent.includes('{') || validationContent.includes('}')) {
-          return null
-        }
-
-        // Encode SVG for data URI - use base64 for better compatibility
-        const base64Svg = Buffer.from(svgContent).toString('base64')
-        const dataUri = `data:image/svg+xml;base64,${base64Svg}`
-
-        // Update cache
-        this.cache.set(cacheKey, { dataUri, sizeBytes, timestamp: now })
-
-        const commandArgs = this.buildHoverCommandArgs(document, range)
-        return this.createHover(dataUri, sizeBytes, range, commandArgs)
-      }
+    if (!candidate) {
+      return null
     }
 
-    return null
+    const startPos = document.positionAt(candidate.startIndex)
+    const endPos = document.positionAt(candidate.startIndex + candidate.length)
+    const range = new vscode.Range(startPos, endPos)
+    const sizeBytes = Buffer.byteLength(candidate.source, 'utf8')
+    const cacheKey = `${document.uri.toString()}:${candidate.kind}:${candidate.startIndex}:${candidate.length}:${candidate.previewSvg.length}`
+    const cached = this.cache.get(cacheKey)
+    const now = Date.now()
+    const commandArgs = candidate.kind === 'svg' ? this.buildHoverCommandArgs(document, range) : null
+
+    if (cached && (now - cached.timestamp) < this.cacheMaxAge) {
+      return this.createHoverFromCache(cached, range, commandArgs)
+    }
+
+    const dataUri = svgToDataUri(candidate.previewSvg)
+    this.cache.set(cacheKey, { dataUri, sizeBytes, timestamp: now })
+
+    return this.createHover(dataUri, sizeBytes, range, commandArgs)
   }
 
   private createHover (
     dataUri: string,
     sizeBytes: number,
     range: vscode.Range,
-    commandArgs: HoverCommandArgs
+    commandArgs: HoverCommandArgs | null
   ): vscode.Hover {
     const markdown = new vscode.MarkdownString()
     markdown.isTrusted = true
     markdown.supportHtml = true
     markdown.appendMarkdown(`![SVG Preview](${dataUri})\n\n`)
     markdown.appendMarkdown(`**Size:** ${this.formatBytes(sizeBytes)}\n\n`)
-    const encodedArgs = encodeURIComponent(JSON.stringify(commandArgs))
-    markdown.appendMarkdown(`[⚡ Optimizar SVG](command:betterSvg.optimizeFromHover?${encodedArgs})`)
+
+    if (commandArgs) {
+      const encodedArgs = encodeURIComponent(JSON.stringify(commandArgs))
+      markdown.appendMarkdown(`[⚡ Optimizar SVG](command:betterSvg.optimizeFromHover?${encodedArgs})`)
+    }
 
     return new vscode.Hover(markdown, range)
   }
@@ -138,9 +110,8 @@ export class SvgHoverProvider implements vscode.HoverProvider {
   private createHoverFromCache (
     cached: SvgCacheEntry,
     range: vscode.Range,
-    document: vscode.TextDocument
+    commandArgs: HoverCommandArgs | null
   ): vscode.Hover {
-    const commandArgs = this.buildHoverCommandArgs(document, range)
     return this.createHover(cached.dataUri, cached.sizeBytes, range, commandArgs)
   }
 
@@ -163,88 +134,6 @@ export class SvgHoverProvider implements vscode.HoverProvider {
       start,
       length: end - start
     }
-  }
-
-  private propagateStrokeAndFill (svgContent: string): string {
-    // Extract stroke and fill from the root <svg> element
-    const svgOpenTagMatch = svgContent.match(/<svg[^>]*>/i)
-    if (!svgOpenTagMatch) return svgContent
-
-    const svgOpenTag = svgOpenTagMatch[0]
-
-    // Extract stroke attribute from svg tag
-    const strokeMatch = svgOpenTag.match(/\bstroke\s*=\s*["']([^"']+)["']/)
-    const stroke = strokeMatch ? strokeMatch[1] : null
-
-    // If there's a stroke on the parent, propagate it to child elements that don't have one
-    if (stroke) {
-      const shapeElements = ['path', 'line', 'polyline', 'polygon', 'circle', 'ellipse', 'rect']
-      const shapeRegex = new RegExp(`<(${shapeElements.join('|')})([^>]*?)(\\/?>)`, 'gi')
-
-      svgContent = svgContent.replace(shapeRegex, (match, tagName, attrs, ending) => {
-        // Check if stroke is already present in attrs
-        if (attrs && /\bstroke\s*=/.test(attrs)) {
-          return match
-        }
-        return `<${tagName}${attrs || ''} stroke="${stroke}"${ending}`
-      })
-    }
-
-    return svgContent
-  }
-
-  private ensureMinimumSize (svgContent: string, minSize: number): string {
-    // Check if SVG has width/height attributes (only in svg tag, not child elements)
-    const svgOpenTagMatch = svgContent.match(/<svg[^>]*>/i)
-    if (!svgOpenTagMatch) return svgContent
-
-    const svgOpenTag = svgOpenTagMatch[0]
-    const hasWidth = /\bwidth\s*=\s*["'][^"']+["']/.test(svgOpenTag)
-    const hasHeight = /\bheight\s*=\s*["'][^"']+["']/.test(svgOpenTag)
-
-    // Try to get dimensions from viewBox if no explicit width/height
-    const viewBoxMatch = svgOpenTag.match(/viewBox\s*=\s*["']([^"']+)["']/)
-
-    if (!hasWidth && !hasHeight) {
-      if (viewBoxMatch) {
-        // Use viewBox dimensions scaled to minSize
-        const viewBoxParts = viewBoxMatch[1].split(/\s+/)
-        if (viewBoxParts.length >= 4) {
-          const vbWidth = parseFloat(viewBoxParts[2])
-          const vbHeight = parseFloat(viewBoxParts[3])
-          const scale = minSize / Math.max(vbWidth, vbHeight)
-          const newWidth = Math.round(vbWidth * scale)
-          const newHeight = Math.round(vbHeight * scale)
-          svgContent = svgContent.replace('<svg', `<svg width="${newWidth}" height="${newHeight}"`)
-        } else {
-          svgContent = svgContent.replace('<svg', `<svg width="${minSize}" height="${minSize}"`)
-        }
-      } else {
-        // No viewBox either, add default size
-        svgContent = svgContent.replace('<svg', `<svg width="${minSize}" height="${minSize}"`)
-      }
-    } else {
-      // Scale up small SVGs
-      const widthMatch = svgOpenTag.match(/\bwidth\s*=\s*["'](\d+(?:\.\d+)?)(?:px)?["']/)
-      const heightMatch = svgOpenTag.match(/\bheight\s*=\s*["'](\d+(?:\.\d+)?)(?:px)?["']/)
-
-      if (widthMatch && heightMatch) {
-        const width = parseFloat(widthMatch[1])
-        const height = parseFloat(heightMatch[1])
-
-        if (width < minSize && height < minSize) {
-          const scale = minSize / Math.max(width, height)
-          const newWidth = Math.round(width * scale)
-          const newHeight = Math.round(height * scale)
-
-          svgContent = svgContent
-            .replace(/\bwidth\s*=\s*["']\d+(?:\.\d+)?(?:px)?["']/, `width="${newWidth}"`)
-            .replace(/\bheight\s*=\s*["']\d+(?:\.\d+)?(?:px)?["']/, `height="${newHeight}"`)
-        }
-      }
-    }
-
-    return svgContent
   }
 
   public clearCache (): void {
@@ -273,55 +162,17 @@ export class SvgGutterPreview {
     }
 
     const text = editor.document.getText()
-    const svgRegex = /<svg[\s\S]*?>[\s\S]*?<\/svg>/g
+    const candidates = collectSvgPreviewCandidates(
+      text,
+      getPreviewOptions(editor.document.languageId, 16)
+    )
     const newDecorationTypes: vscode.TextEditorDecorationType[] = []
 
-    let match
-    while ((match = svgRegex.exec(text))) {
-      const startPos = editor.document.positionAt(match.index)
+    for (const candidate of candidates) {
+      const startPos = editor.document.positionAt(candidate.startIndex)
       // Use a zero-length range at the start of the SVG to ensure only one gutter icon is shown
       const range = new vscode.Range(startPos, startPos)
-
-      let svgContent = match[0]
-      const options = {
-        useCamelCase: ['javascriptreact', 'typescriptreact'].includes(editor.document.languageId)
-      }
-
-      // Convert JSX syntax to valid SVG
-      svgContent = convertJsxToSvg(svgContent, options)
-
-      // Add xmlns if missing (do this early so SVG is valid)
-      // Check ONLY inside the opening <svg ... > tag
-      const svgOpenTagMatch = svgContent.match(/<svg[^>]*>/i)
-      const hasXmlnsInRoot = svgOpenTagMatch && /xmlns\s*=\s*["']/.test(svgOpenTagMatch[0])
-      
-      if (!hasXmlnsInRoot) {
-        svgContent = svgContent.replace(/<svg/, '<svg xmlns="http://www.w3.org/2000/svg"')
-      }
-
-      // Replace currentColor based on theme
-      const isDarkTheme = vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark ||
-                          vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.HighContrast
-
-      const contrastColor = isDarkTheme ? '#ffffff' : '#000000'
-
-      svgContent = svgContent.replace(/currentColor/g, contrastColor)
-
-      // Propagate stroke/fill from parent to children (after currentColor is resolved)
-      svgContent = this.propagateStrokeAndFill(svgContent)
-
-      // Ensure minimum size for gutter icon
-      svgContent = this.ensureMinimumSize(svgContent, 16)
-
-      // Validate that the SVG is likely to be renderable.
-      const validationContent = svgContent.replace(/<style[\s\S]*?<\/style>/gi, '')
-      if (validationContent.includes('{') || validationContent.includes('}')) {
-        continue
-      }
-
-      // Encode SVG content for data URI - use base64 for better compatibility
-      const base64Svg = Buffer.from(svgContent).toString('base64')
-      const dataUri = `data:image/svg+xml;base64,${base64Svg}`
+      const dataUri = svgToDataUri(candidate.previewSvg)
 
       const decorationType = vscode.window.createTextEditorDecorationType({
         gutterIconPath: vscode.Uri.parse(dataUri),
@@ -342,67 +193,6 @@ export class SvgGutterPreview {
       types.forEach(t => t.dispose())
       this.decorationTypes.delete(uri)
     }
-  }
-
-  private propagateStrokeAndFill (svgContent: string): string {
-    // Extract stroke and fill from the root <svg> element
-    const svgOpenTagMatch = svgContent.match(/<svg[^>]*>/i)
-    if (!svgOpenTagMatch) return svgContent
-
-    const svgOpenTag = svgOpenTagMatch[0]
-
-    // Extract stroke attribute from svg tag
-    const strokeMatch = svgOpenTag.match(/\bstroke\s*=\s*["']([^"']+)["']/)
-    const stroke = strokeMatch ? strokeMatch[1] : null
-
-    // If there's a stroke on the parent, propagate it to child elements that don't have one
-    if (stroke) {
-      const shapeElements = ['path', 'line', 'polyline', 'polygon', 'circle', 'ellipse', 'rect']
-      const shapeRegex = new RegExp(`<(${shapeElements.join('|')})([^>]*?)(\\/?>)`, 'gi')
-
-      svgContent = svgContent.replace(shapeRegex, (match, tagName, attrs, ending) => {
-        // Check if stroke is already present in attrs
-        if (attrs && /\bstroke\s*=/.test(attrs)) {
-          return match
-        }
-        return `<${tagName}${attrs || ''} stroke="${stroke}"${ending}`
-      })
-    }
-
-    return svgContent
-  }
-
-  private ensureMinimumSize (svgContent: string, minSize: number): string {
-    // Check if SVG has width/height attributes (only in svg tag, not child elements)
-    const svgOpenTagMatch = svgContent.match(/<svg[^>]*>/i)
-    if (!svgOpenTagMatch) return svgContent
-
-    const svgOpenTag = svgOpenTagMatch[0]
-    const hasWidth = /\bwidth\s*=\s*["'][^"']+["']/.test(svgOpenTag)
-    const hasHeight = /\bheight\s*=\s*["'][^"']+["']/.test(svgOpenTag)
-
-    // Try to get dimensions from viewBox if no explicit width/height
-    const viewBoxMatch = svgOpenTag.match(/viewBox\s*=\s*["']([^"']+)["']/)
-
-    if (!hasWidth && !hasHeight) {
-      if (viewBoxMatch) {
-        const viewBoxParts = viewBoxMatch[1].split(/\s+/)
-        if (viewBoxParts.length >= 4) {
-          const vbWidth = parseFloat(viewBoxParts[2])
-          const vbHeight = parseFloat(viewBoxParts[3])
-          const scale = minSize / Math.max(vbWidth, vbHeight)
-          const newWidth = Math.round(vbWidth * scale)
-          const newHeight = Math.round(vbHeight * scale)
-          svgContent = svgContent.replace('<svg', `<svg width="${newWidth}" height="${newHeight}"`)
-        } else {
-          svgContent = svgContent.replace('<svg', `<svg width="${minSize}" height="${minSize}"`)
-        }
-      } else {
-        svgContent = svgContent.replace('<svg', `<svg width="${minSize}" height="${minSize}"`)
-      }
-    }
-
-    return svgContent
   }
 
   public dispose () {

--- a/src/svgPreview.test.ts
+++ b/src/svgPreview.test.ts
@@ -1,0 +1,121 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import {
+  collectSvgPreviewCandidates,
+  findSvgPreviewAtOffset,
+  svgToDataUri,
+  type SvgPreviewOptions
+} from './svgPreview'
+
+const previewOptions: SvgPreviewOptions = {
+  contrastColor: '#000000',
+  minSize: 16,
+  useCamelCase: false
+}
+
+describe('collectSvgPreviewCandidates', () => {
+  it('keeps existing inline svg previews working', () => {
+    const [candidate] = collectSvgPreviewCandidates(
+      '<svg viewBox="0 0 24 24"><path fill="currentColor" d="M0 0h24v24H0z"/></svg>',
+      previewOptions
+    )
+
+    assert.strictEqual(candidate.kind, 'svg')
+    assert.ok(candidate.previewSvg.includes('xmlns="http://www.w3.org/2000/svg"'))
+    assert.ok(candidate.previewSvg.includes('width="16" height="16"'))
+    assert.ok(candidate.previewSvg.includes('fill="#000000"'))
+  })
+
+  it('creates renderable previews for symbol definitions', () => {
+    const documentText = `<svg class="hidden">
+      <symbol id="icon-clock" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10"/>
+        <path d="M12 6v6l4 2"/>
+      </symbol>
+    </svg>`
+
+    const symbolCandidate = collectSvgPreviewCandidates(documentText, previewOptions)
+      .find(candidate => candidate.kind === 'symbol')
+
+    assert.ok(symbolCandidate)
+    assert.ok(symbolCandidate.previewSvg.startsWith('<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"'))
+    assert.ok(symbolCandidate.previewSvg.includes('viewBox="0 0 24 24"'))
+    assert.ok(symbolCandidate.previewSvg.includes('<circle cx="12" cy="12" r="10"/>'))
+    assert.ok(!symbolCandidate.previewSvg.includes('<symbol'))
+  })
+
+  it('resolves use references inside svg previews from symbols in the same document', () => {
+    const documentText = `<svg class="hidden">
+      <symbol id="icon-location" viewBox="0 0 24 24">
+        <path d="M12 0C7.8 0 4 3.4 4 8"/>
+      </symbol>
+    </svg>
+    <svg class="w-5 h-5"><use href="#icon-location"/></svg>`
+
+    const useSvgCandidate = collectSvgPreviewCandidates(documentText, previewOptions)
+      .find(candidate => candidate.kind === 'svg' && candidate.source.includes('<use'))
+
+    assert.ok(useSvgCandidate)
+    assert.ok(useSvgCandidate.previewSvg.includes('viewBox="0 0 24 24"'))
+    assert.ok(useSvgCandidate.previewSvg.includes('<defs><symbol id="icon-location"'))
+    assert.ok(useSvgCandidate.previewSvg.includes('<use href="#icon-location"/>'))
+  })
+
+  it('creates standalone previews for use references', () => {
+    const documentText = `<svg class="hidden">
+      <symbol id="icon-location" viewBox="0 0 24 24">
+        <path d="M12 0C7.8 0 4 3.4 4 8"/>
+      </symbol>
+    </svg>
+    <svg class="w-5 h-5"><use href="#icon-location"/></svg>`
+
+    const useCandidate = collectSvgPreviewCandidates(documentText, previewOptions)
+      .find(candidate => candidate.kind === 'use')
+
+    assert.ok(useCandidate)
+    assert.ok(useCandidate.previewSvg.includes('<defs><symbol id="icon-location"'))
+    assert.ok(useCandidate.previewSvg.includes('<use href="#icon-location"/>'))
+    assert.ok(useCandidate.previewSvg.includes('viewBox="0 0 24 24"'))
+  })
+
+  it('resolves JSX xlinkHref use references', () => {
+    const documentText = `<svg>
+      <symbol id="icon-clock" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></symbol>
+    </svg>
+    <svg><use xlinkHref="#icon-clock" /></svg>`
+
+    const useSvgCandidate = collectSvgPreviewCandidates(documentText, {
+      ...previewOptions,
+      useCamelCase: true
+    }).find(candidate => candidate.kind === 'svg' && candidate.source.includes('xlinkHref'))
+
+    assert.ok(useSvgCandidate)
+    assert.ok(useSvgCandidate.previewSvg.includes('<defs><symbol id="icon-clock"'))
+    assert.ok(useSvgCandidate.previewSvg.includes('xlink:href="#icon-clock"'))
+  })
+
+  it('ignores use references without a matching symbol', () => {
+    const candidates = collectSvgPreviewCandidates('<use href="#missing"/>', previewOptions)
+
+    assert.deepStrictEqual(candidates, [])
+  })
+})
+
+describe('findSvgPreviewAtOffset', () => {
+  it('prefers the nested use preview over the surrounding svg preview', () => {
+    const documentText = `<svg><symbol id="icon" viewBox="0 0 10 10"><path d="M0 0h10v10H0z"/></symbol></svg>
+    <svg><use href="#icon"/></svg>`
+    const offset = documentText.indexOf('<use') + 1
+    const candidate = findSvgPreviewAtOffset(documentText, offset, previewOptions)
+
+    assert.strictEqual(candidate?.kind, 'use')
+  })
+})
+
+describe('svgToDataUri', () => {
+  it('encodes renderable svg as an image data uri', () => {
+    const dataUri = svgToDataUri('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+
+    assert.ok(dataUri.startsWith('data:image/svg+xml;base64,'))
+  })
+})

--- a/src/svgPreview.ts
+++ b/src/svgPreview.ts
@@ -326,10 +326,16 @@ function getAttribute (attrs: string, name: string): string | null {
 }
 
 function omitAttributes (attrs: string, names: string[]): string {
-  return names.reduce((result, name) => {
+  const result = names.reduce((currentAttrs, name) => {
     const escapedName = escapeRegExp(name)
-    return result.replace(new RegExp(`\\s*\\b${escapedName}\\s*=\\s*(["']).*?\\1`, 'gi'), '')
+    return currentAttrs.replace(new RegExp(`\\s*\\b${escapedName}\\s*=\\s*(["']).*?\\1`, 'gi'), '')
   }, attrs)
+
+  if (result.length > 0 && !/^\s/.test(result)) {
+    return ` ${result}`
+  }
+
+  return result
 }
 
 function escapeRegExp (value: string): string {

--- a/src/svgPreview.ts
+++ b/src/svgPreview.ts
@@ -1,0 +1,337 @@
+/**
+ * Copyright 2025 Miguel Ángel Durán
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { convertJsxToSvg, type OptimizationOptions } from './svgTransform'
+
+export type SvgPreviewKind = 'svg' | 'symbol' | 'use'
+
+export interface SvgPreviewCandidate {
+  kind: SvgPreviewKind
+  source: string
+  previewSvg: string
+  startIndex: number
+  length: number
+}
+
+export interface SvgPreviewOptions extends OptimizationOptions {
+  contrastColor: string
+  minSize: number
+}
+
+interface SvgSymbolDefinition {
+  id: string
+  source: string
+  attrs: string
+  inner: string
+}
+
+const SVG_TAG_REGEX = /<svg\b[\s\S]*?>[\s\S]*?<\/svg>/gi
+const SYMBOL_TAG_REGEX = /<symbol\b([^>]*)>([\s\S]*?)<\/symbol>/gi
+const USE_TAG_REGEX = /<use\b[^>]*(?:\/>|>[\s\S]*?<\/use>)/gi
+
+export function collectSvgPreviewCandidates (documentText: string, options: SvgPreviewOptions): SvgPreviewCandidate[] {
+  const convertedDocumentText = convertJsxToSvg(documentText, options)
+  const symbols = collectSymbols(convertedDocumentText)
+  const candidates: SvgPreviewCandidate[] = []
+
+  addMatches(documentText, SVG_TAG_REGEX, 'svg', candidates, (source) => buildSvgPreview(source, symbols, options))
+  addMatches(documentText, SYMBOL_TAG_REGEX, 'symbol', candidates, (source) => buildSymbolPreview(source, options))
+  addMatches(documentText, USE_TAG_REGEX, 'use', candidates, (source) => buildUsePreview(source, symbols, options))
+
+  return candidates.sort((a, b) => a.startIndex - b.startIndex || a.length - b.length)
+}
+
+export function findSvgPreviewAtOffset (documentText: string, offset: number, options: SvgPreviewOptions): SvgPreviewCandidate | null {
+  const candidates = collectSvgPreviewCandidates(documentText, options)
+    .filter(candidate => offset >= candidate.startIndex && offset <= candidate.startIndex + candidate.length)
+    .sort((a, b) => a.length - b.length)
+
+  return candidates[0] ?? null
+}
+
+export function svgToDataUri (svgContent: string): string {
+  const base64Svg = Buffer.from(svgContent).toString('base64')
+  return `data:image/svg+xml;base64,${base64Svg}`
+}
+
+function addMatches (
+  documentText: string,
+  regex: RegExp,
+  kind: SvgPreviewKind,
+  candidates: SvgPreviewCandidate[],
+  buildPreview: (source: string) => string | null
+): void {
+  regex.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(documentText))) {
+    const source = match[0]
+    const previewSvg = buildPreview(source)
+    if (!previewSvg) {
+      continue
+    }
+
+    candidates.push({
+      kind,
+      source,
+      previewSvg,
+      startIndex: match.index,
+      length: source.length
+    })
+  }
+}
+
+function collectSymbols (documentText: string): Map<string, SvgSymbolDefinition> {
+  const symbols = new Map<string, SvgSymbolDefinition>()
+  let match: RegExpExecArray | null
+
+  SYMBOL_TAG_REGEX.lastIndex = 0
+  while ((match = SYMBOL_TAG_REGEX.exec(documentText))) {
+    const attrs = match[1] ?? ''
+    const id = getAttribute(attrs, 'id')
+    if (!id) {
+      continue
+    }
+
+    symbols.set(id, {
+      id,
+      source: match[0],
+      attrs,
+      inner: match[2] ?? ''
+    })
+  }
+
+  return symbols
+}
+
+function buildSvgPreview (
+  source: string,
+  symbols: Map<string, SvgSymbolDefinition>,
+  options: SvgPreviewOptions
+): string | null {
+  const svgContent = convertJsxToSvg(source, options)
+  return preparePreviewSvg(resolveUseReferences(svgContent, symbols), options)
+}
+
+function buildSymbolPreview (source: string, options: SvgPreviewOptions): string | null {
+  const symbolContent = convertJsxToSvg(source, options)
+  const match = symbolContent.match(/^<symbol\b([^>]*)>([\s\S]*?)<\/symbol>$/i)
+  if (!match) {
+    return null
+  }
+
+  const attrs = omitAttributes(match[1] ?? '', ['id'])
+  return preparePreviewSvg(`<svg${attrs}>${match[2] ?? ''}</svg>`, options)
+}
+
+function buildUsePreview (
+  source: string,
+  symbols: Map<string, SvgSymbolDefinition>,
+  options: SvgPreviewOptions
+): string | null {
+  const useContent = convertJsxToSvg(source, options)
+  const referenceId = getUseReferenceId(useContent)
+  if (!referenceId) {
+    return null
+  }
+
+  const symbol = symbols.get(referenceId)
+  if (!symbol) {
+    return null
+  }
+
+  const rootAttrs = omitAttributes(symbol.attrs, ['id'])
+  return preparePreviewSvg(`<svg${rootAttrs}><defs>${symbol.source}</defs>${useContent}</svg>`, options)
+}
+
+function resolveUseReferences (svgContent: string, symbols: Map<string, SvgSymbolDefinition>): string {
+  const referenceIds = getUseReferenceIds(svgContent)
+    .filter(id => !hasSymbolDefinition(svgContent, id) && symbols.has(id))
+
+  if (referenceIds.length === 0) {
+    return svgContent
+  }
+
+  const uniqueReferenceIds = [...new Set(referenceIds)]
+  const defs = uniqueReferenceIds
+    .map(id => symbols.get(id)?.source)
+    .filter((source): source is string => Boolean(source))
+    .join('')
+
+  let resolvedSvg = ensureRootViewBox(svgContent, symbols.get(uniqueReferenceIds[0]))
+  resolvedSvg = resolvedSvg.replace(/<svg\b[^>]*>/i, match => `${match}<defs>${defs}</defs>`)
+
+  return resolvedSvg
+}
+
+function preparePreviewSvg (svgContent: string, options: SvgPreviewOptions): string | null {
+  let previewSvg = ensureXmlns(svgContent)
+  previewSvg = previewSvg.replace(/currentColor/g, options.contrastColor)
+  previewSvg = propagateStrokeAndFill(previewSvg)
+  previewSvg = ensureMinimumSize(previewSvg, options.minSize)
+
+  const validationContent = previewSvg.replace(/<style[\s\S]*?<\/style>/gi, '')
+  if (validationContent.includes('{') || validationContent.includes('}')) {
+    return null
+  }
+
+  return previewSvg
+}
+
+function ensureXmlns (svgContent: string): string {
+  const svgOpenTagMatch = svgContent.match(/<svg[^>]*>/i)
+  const hasXmlnsInRoot = svgOpenTagMatch && /xmlns\s*=\s*["']/.test(svgOpenTagMatch[0])
+
+  if (hasXmlnsInRoot) {
+    return svgContent
+  }
+
+  return svgContent.replace(/<svg/i, '<svg xmlns="http://www.w3.org/2000/svg"')
+}
+
+function propagateStrokeAndFill (svgContent: string): string {
+  const svgOpenTagMatch = svgContent.match(/<svg[^>]*>/i)
+  if (!svgOpenTagMatch) return svgContent
+
+  const svgOpenTag = svgOpenTagMatch[0]
+  const stroke = getAttribute(svgOpenTag, 'stroke')
+
+  if (!stroke) {
+    return svgContent
+  }
+
+  const shapeElements = ['path', 'line', 'polyline', 'polygon', 'circle', 'ellipse', 'rect']
+  const shapeRegex = new RegExp(`<(${shapeElements.join('|')})([^>]*?)(\\/?>)`, 'gi')
+
+  return svgContent.replace(shapeRegex, (match, tagName, attrs, ending) => {
+    if (attrs && /\bstroke\s*=/.test(attrs)) {
+      return match
+    }
+
+    return `<${tagName}${attrs || ''} stroke="${stroke}"${ending}`
+  })
+}
+
+function ensureMinimumSize (svgContent: string, minSize: number): string {
+  const svgOpenTagMatch = svgContent.match(/<svg[^>]*>/i)
+  if (!svgOpenTagMatch) return svgContent
+
+  const svgOpenTag = svgOpenTagMatch[0]
+  const hasWidth = /\bwidth\s*=\s*["'][^"']+["']/.test(svgOpenTag)
+  const hasHeight = /\bheight\s*=\s*["'][^"']+["']/.test(svgOpenTag)
+  const viewBox = getAttribute(svgOpenTag, 'viewBox')
+
+  if (!hasWidth && !hasHeight) {
+    if (viewBox) {
+      const viewBoxParts = viewBox.split(/\s+/)
+      if (viewBoxParts.length >= 4) {
+        const vbWidth = parseFloat(viewBoxParts[2])
+        const vbHeight = parseFloat(viewBoxParts[3])
+        const scale = minSize / Math.max(vbWidth, vbHeight)
+        const newWidth = Math.round(vbWidth * scale)
+        const newHeight = Math.round(vbHeight * scale)
+        return svgContent.replace('<svg', `<svg width="${newWidth}" height="${newHeight}"`)
+      }
+    }
+
+    return svgContent.replace('<svg', `<svg width="${minSize}" height="${minSize}"`)
+  }
+
+  const widthMatch = svgOpenTag.match(/\bwidth\s*=\s*["'](\d+(?:\.\d+)?)(?:px)?["']/)
+  const heightMatch = svgOpenTag.match(/\bheight\s*=\s*["'](\d+(?:\.\d+)?)(?:px)?["']/)
+
+  if (!widthMatch || !heightMatch) {
+    return svgContent
+  }
+
+  const width = parseFloat(widthMatch[1])
+  const height = parseFloat(heightMatch[1])
+
+  if (width >= minSize || height >= minSize) {
+    return svgContent
+  }
+
+  const scale = minSize / Math.max(width, height)
+  const newWidth = Math.round(width * scale)
+  const newHeight = Math.round(height * scale)
+
+  return svgContent
+    .replace(/\bwidth\s*=\s*["']\d+(?:\.\d+)?(?:px)?["']/, `width="${newWidth}"`)
+    .replace(/\bheight\s*=\s*["']\d+(?:\.\d+)?(?:px)?["']/, `height="${newHeight}"`)
+}
+
+function ensureRootViewBox (svgContent: string, symbol: SvgSymbolDefinition | undefined): string {
+  if (!symbol) {
+    return svgContent
+  }
+
+  const svgOpenTagMatch = svgContent.match(/<svg[^>]*>/i)
+  if (!svgOpenTagMatch || /\bviewBox\s*=/.test(svgOpenTagMatch[0])) {
+    return svgContent
+  }
+
+  const viewBox = getAttribute(symbol.attrs, 'viewBox')
+  if (!viewBox) {
+    return svgContent
+  }
+
+  return svgContent.replace(/<svg\b([^>]*)>/i, `<svg$1 viewBox="${viewBox}">`)
+}
+
+function hasSymbolDefinition (svgContent: string, id: string): boolean {
+  const escapedId = escapeRegExp(id)
+  return new RegExp(`<symbol\\b[^>]*\\bid\\s*=\\s*["']${escapedId}["']`, 'i').test(svgContent)
+}
+
+function getUseReferenceIds (svgContent: string): string[] {
+  const referenceIds: string[] = []
+  let match: RegExpExecArray | null
+
+  USE_TAG_REGEX.lastIndex = 0
+  while ((match = USE_TAG_REGEX.exec(svgContent))) {
+    const id = getUseReferenceId(match[0])
+    if (id) {
+      referenceIds.push(id)
+    }
+  }
+
+  return referenceIds
+}
+
+function getUseReferenceId (useTag: string): string | null {
+  const href = getAttribute(useTag, 'href') ?? getAttribute(useTag, 'xlink:href')
+  if (!href?.startsWith('#')) {
+    return null
+  }
+
+  return href.slice(1)
+}
+
+function getAttribute (attrs: string, name: string): string | null {
+  const escapedName = escapeRegExp(name)
+  const match = attrs.match(new RegExp(`\\b${escapedName}\\s*=\\s*(["'])(.*?)\\1`, 'i'))
+  return match?.[2] ?? null
+}
+
+function omitAttributes (attrs: string, names: string[]): string {
+  return names.reduce((result, name) => {
+    const escapedName = escapeRegExp(name)
+    return result.replace(new RegExp(`\\s*\\b${escapedName}\\s*=\\s*(["']).*?\\1`, 'gi'), '')
+  }, attrs)
+}
+
+function escapeRegExp (value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}


### PR DESCRIPTION
SVG sprite workflows define icons with `<symbol>` and render them through `<use href="#id">`, but the gutter and hover previews only handled standalone `<svg>` blocks. This adds a shared preview extraction layer that can render symbols directly and resolve local symbol references for use elements.

## Changes

- Adds preview candidate collection for `<svg>`, `<symbol>`, and `<use>` elements.
- Resolves local `<use href="#id">` and JSX `xlinkHref` references by injecting the matching symbol into preview-only `<defs>`.
- Keeps existing SVG sizing, xmlns, currentColor, and stroke propagation behavior in the shared preview pipeline.
- Adds unit coverage for normal SVGs, symbol definitions, use references, JSX xlinkHref, missing references, and nested hover selection.

Closes #12