### PR TITLE
Add Blade SVG support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Better SVG isn't just for `.svg` files. It understands SVG syntax inside a wide 
 - **Vue**: `.vue`
 - **Astro**: `.astro`
 - **Svelte**: `.svelte`
+- **Laravel Blade**: `.blade.php`
 
 The extension automatically detects SVG tags within these files, providing gutter icons, hover previews, and framework-aware optimization.
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "activationEvents": [
     "onLanguage:astro",
+    "onLanguage:blade",
     "onLanguage:django-html",
     "onLanguage:ejs",
     "onLanguage:erb",
@@ -87,6 +88,15 @@
       ]
     },
     "languages": [
+      {
+        "id": "blade",
+        "aliases": [
+          "Blade"
+        ],
+        "extensions": [
+          ".blade.php"
+        ]
+      },
       {
         "id": "liquid",
         "aliases": [

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -16,6 +16,7 @@
 
 export const SUPPORTED_LANGUAGES = [
   'astro',
+  'blade',
   'django-html',
   'ejs',
   'erb',

--- a/src/frameworks.test.ts
+++ b/src/frameworks.test.ts
@@ -1,185 +1,224 @@
-
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
+import { readFileSync } from 'node:fs'
 import {
   prepareForOptimization,
-  finalizeAfterOptimization,
-  isJsxSvg
+  finalizeAfterOptimization
 } from './svgTransform'
+import { SUPPORTED_LANGUAGES } from './consts'
 
 describe('Astro Support', () => {
-    it('should handle Astro expression syntax (similar to JSX)', () => {
-        const input = '<svg width={size} height={size}><path d={path} /></svg>'
-        const { preparedSvg, wasJsx } = prepareForOptimization(input)
-        
-        // Should be detected as "JSX-like"
-        assert.ok(wasJsx, 'Should detect Astro/JSX expression')
-        assert.ok(preparedSvg.includes('data-better-svg-temp-width='))
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx)
-        assert.strictEqual(final, input)
-    })
+  it('should handle Astro expression syntax (similar to JSX)', () => {
+    const input = '<svg width={size} height={size}><path d={path} /></svg>'
+    const { preparedSvg, wasJsx } = prepareForOptimization(input)
 
-    it('should handle Astro class:list', () => {
-        const input = '<svg class:list={["icon", className]}></svg>'
-        const { preparedSvg, wasJsx } = prepareForOptimization(input)
-        
-        // class:list is a valid attribute name with : (namespace-like)
-        // It has expression value ={...}
-        assert.ok(wasJsx)
-        assert.ok(preparedSvg.includes('data-better-svg-temp-class__COLON__list='))
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx)
-        assert.strictEqual(final, input)
-    })
+    // Should be detected as "JSX-like"
+    assert.ok(wasJsx, 'Should detect Astro/JSX expression')
+    assert.ok(preparedSvg.includes('data-better-svg-temp-width='))
 
-    it('should preserve Astro boolean directives like client:only', () => {
-        const input = '<svg client:only xmlns="http://www.w3.org/2000/svg"></svg>'
-        const { preparedSvg, wasJsx } = prepareForOptimization(input)
-        
-        // isJsxSvg needs to recognize client:only as a reason to be JSX/Astro
-        assert.ok(wasJsx, 'Should detect client:only as Astro/JSX')
-        
-        // Should be protected
-        assert.ok(preparedSvg.includes('data-better-svg-temp-client__COLON__only'), `Should be protected: ${preparedSvg}`)
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx)
-        assert.ok(final.includes('client:only'), `Final result missing client:only: ${final}`)
-    })
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx)
+    assert.strictEqual(final, input)
+  })
+
+  it('should handle Astro class:list', () => {
+    const input = '<svg class:list={["icon", className]}></svg>'
+    const { preparedSvg, wasJsx } = prepareForOptimization(input)
+
+    // class:list is a valid attribute name with : (namespace-like)
+    // It has expression value ={...}
+    assert.ok(wasJsx)
+    assert.ok(preparedSvg.includes('data-better-svg-temp-class__COLON__list='))
+
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx)
+    assert.strictEqual(final, input)
+  })
+
+  it('should preserve Astro boolean directives like client:only', () => {
+    const input = '<svg client:only xmlns="http://www.w3.org/2000/svg"></svg>'
+    const { preparedSvg, wasJsx } = prepareForOptimization(input)
+
+    // isJsxSvg needs to recognize client:only as a reason to be JSX/Astro
+    assert.ok(wasJsx, 'Should detect client:only as Astro/JSX')
+
+    // Should be protected
+    assert.ok(preparedSvg.includes('data-better-svg-temp-client__COLON__only'), `Should be protected: ${preparedSvg}`)
+
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx)
+    assert.ok(final.includes('client:only'), `Final result missing client:only: ${final}`)
+  })
 })
 
-
 describe('Vue Support', () => {
-    // Vue uses :attr="value" or v-bind:attr="value"
-    // CAUTION: The current `svgTransform` logic focuses on JSX-style `={}` expressions.
-    // If Vue uses quotes `:width="size"`, replaceJsxExpressions will NOT touch it because it looks for `={`.
-    // SVGO might strip `:width` if it doesn't recognize it.
-    
-    it('should preserve Vue :bound attributes', () => {
-        const input = '<svg :width="size" :height="size"><path /></svg>'
-        const { preparedSvg, wasJsx } = prepareForOptimization(input)
-        
-        // Now it detects and protects Vue syntax
-        assert.strictEqual(wasJsx, true)
-        assert.ok(preparedSvg.includes('data-better-svg-temp-__COLON__width="size"'))
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx)
-        assert.strictEqual(final, input)
-    })
+  // Vue uses :attr="value" or v-bind:attr="value"
+  // CAUTION: The current `svgTransform` logic focuses on JSX-style `={}` expressions.
+  // If Vue uses quotes `:width="size"`, replaceJsxExpressions will NOT touch it because it looks for `={`.
+  // SVGO might strip `:width` if it doesn't recognize it.
 
-    it('should preserve Vue v-bind attributes', () => {
-        const input = '<svg v-bind:width="size"></svg>'
-        const { preparedSvg, wasJsx } = prepareForOptimization(input)
-        assert.strictEqual(wasJsx, true)
-        assert.ok(preparedSvg.includes('data-better-svg-temp-v-bind__COLON__width="size"'))
-    })
-    
-    it('should preserve Vue @event handlers', () => {
-        const input = '<svg @click="handleClick"></svg>'
-        const { preparedSvg, wasJsx } = prepareForOptimization(input)
-        assert.strictEqual(wasJsx, true)
-        assert.ok(preparedSvg.includes('data-better-svg-temp-__AT__click="handleClick"'))
-    })
+  it('should preserve Vue :bound attributes', () => {
+    const input = '<svg :width="size" :height="size"><path /></svg>'
+    const { preparedSvg, wasJsx } = prepareForOptimization(input)
 
-    it('should NOT convert kebab-case to camelCase in Astro/Vue (useCamelCase: false)', () => {
-        const input = '<svg class:list={["foo"]} stroke-width="2"></svg>'
-        const options = { useCamelCase: false }
-        const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
-        
-        assert.ok(wasJsx)
-        // Should preserve stroke-width as is
-        assert.ok(!preparedSvg.includes('strokeWidth'))
-        assert.ok(preparedSvg.includes('stroke-width'))
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
-        assert.strictEqual(final, input)
-    })
+    // Now it detects and protects Vue syntax
+    assert.strictEqual(wasJsx, true)
+    assert.ok(preparedSvg.includes('data-better-svg-temp-__COLON__width="size"'))
 
-    it('should handle Astro define:vars with style object', () => {
-        const input = '<svg define:vars={{ color: "red" }}></svg>'
-        const options = { useCamelCase: false }
-        const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
-        
-        assert.ok(wasJsx)
-        assert.ok(preparedSvg.includes('data-better-svg-temp-define__COLON__vars'))
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
-        assert.strictEqual(final, input)
-    })
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx)
+    assert.strictEqual(final, input)
+  })
+
+  it('should preserve Vue v-bind attributes', () => {
+    const input = '<svg v-bind:width="size"></svg>'
+    const { preparedSvg, wasJsx } = prepareForOptimization(input)
+    assert.strictEqual(wasJsx, true)
+    assert.ok(preparedSvg.includes('data-better-svg-temp-v-bind__COLON__width="size"'))
+  })
+
+  it('should preserve Vue @event handlers', () => {
+    const input = '<svg @click="handleClick"></svg>'
+    const { preparedSvg, wasJsx } = prepareForOptimization(input)
+    assert.strictEqual(wasJsx, true)
+    assert.ok(preparedSvg.includes('data-better-svg-temp-__AT__click="handleClick"'))
+  })
+
+  it('should NOT convert kebab-case to camelCase in Astro/Vue (useCamelCase: false)', () => {
+    const input = '<svg class:list={["foo"]} stroke-width="2"></svg>'
+    const options = { useCamelCase: false }
+    const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
+
+    assert.ok(wasJsx)
+    // Should preserve stroke-width as is
+    assert.ok(!preparedSvg.includes('strokeWidth'))
+    assert.ok(preparedSvg.includes('stroke-width'))
+
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
+    assert.strictEqual(final, input)
+  })
+
+  it('should handle Astro define:vars with style object', () => {
+    const input = '<svg define:vars={{ color: "red" }}></svg>'
+    const options = { useCamelCase: false }
+    const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
+
+    assert.ok(wasJsx)
+    assert.ok(preparedSvg.includes('data-better-svg-temp-define__COLON__vars'))
+
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
+    assert.strictEqual(final, input)
+  })
 })
 
 describe('Svelte Support', () => {
-    const options = { useCamelCase: false }
+  const options = { useCamelCase: false }
 
-    it('should handle Svelte on:event handlers', () => {
-        const input = '<svg on:click={handleClick} on:mousedown={() => {}}></svg>'
-        const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
-        
-        assert.ok(wasJsx)
-        assert.ok(preparedSvg.includes('data-better-svg-temp-on__COLON__click'))
-        assert.ok(preparedSvg.includes('data-better-svg-temp-on__COLON__mousedown'))
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
-        assert.strictEqual(final, input)
-    })
+  it('should handle Svelte on:event handlers', () => {
+    const input = '<svg on:click={handleClick} on:mousedown={() => {}}></svg>'
+    const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
 
-    it('should handle Svelte bind:this and other bindings', () => {
-        const input = '<svg bind:this={svgRef} bind:clientWidth={w}></svg>'
-        const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
-        
-        assert.ok(wasJsx)
-        assert.ok(preparedSvg.includes('data-better-svg-temp-bind__COLON__this'))
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
-        assert.strictEqual(final, input)
-    })
+    assert.ok(wasJsx)
+    assert.ok(preparedSvg.includes('data-better-svg-temp-on__COLON__click'))
+    assert.ok(preparedSvg.includes('data-better-svg-temp-on__COLON__mousedown'))
 
-    it('should handle Svelte class:active shorthand', () => {
-        const input = '<svg class:active={isActive} class:red></svg>'
-        const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
-        
-        assert.ok(wasJsx)
-        assert.ok(preparedSvg.includes('data-better-svg-temp-class__COLON__active'))
-        assert.ok(preparedSvg.includes('data-better-svg-temp-class__COLON__red'))
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
-        assert.strictEqual(final, input)
-    })
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
+    assert.strictEqual(final, input)
+  })
 
-    it('should handle Svelte interpolations in text', () => {
-        const input = '<svg><text>{Math.random() > 0.5 ? "H" : "L"}</text></svg>'
-        const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
-        
-        assert.ok(wasJsx)
-        assert.ok(preparedSvg.includes('__JSX_BASE64__'))
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
-        assert.strictEqual(final, input)
-    })
+  it('should handle Svelte bind:this and other bindings', () => {
+    const input = '<svg bind:this={svgRef} bind:clientWidth={w}></svg>'
+    const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
+
+    assert.ok(wasJsx)
+    assert.ok(preparedSvg.includes('data-better-svg-temp-bind__COLON__this'))
+
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
+    assert.strictEqual(final, input)
+  })
+
+  it('should handle Svelte class:active shorthand', () => {
+    const input = '<svg class:active={isActive} class:red></svg>'
+    const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
+
+    assert.ok(wasJsx)
+    assert.ok(preparedSvg.includes('data-better-svg-temp-class__COLON__active'))
+    assert.ok(preparedSvg.includes('data-better-svg-temp-class__COLON__red'))
+
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
+    assert.strictEqual(final, input)
+  })
+
+  it('should handle Svelte interpolations in text', () => {
+    const input = '<svg><text>{Math.random() > 0.5 ? "H" : "L"}</text></svg>'
+    const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
+
+    assert.ok(wasJsx)
+    assert.ok(preparedSvg.includes('__JSX_BASE64__'))
+
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
+    assert.strictEqual(final, input)
+  })
+})
+
+describe('Blade Support', () => {
+  const options = { useCamelCase: false }
+
+  it('should register Blade as a supported language', () => {
+    assert.ok(SUPPORTED_LANGUAGES.includes('blade'))
+  })
+
+  it('should activate VS Code support for .blade.php files', () => {
+    const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
+      activationEvents: string[]
+      contributes: {
+        languages: Array<{
+          id: string
+          extensions?: string[]
+        }>
+      }
+    }
+
+    assert.ok(packageJson.activationEvents.includes('onLanguage:blade'))
+    assert.ok(packageJson.contributes.languages.some((language) => {
+      return language.id === 'blade' && language.extensions?.includes('.blade.php')
+    }))
+  })
+
+  it('should preserve Blade attribute bags, directives and echoed values', () => {
+    const input = '<svg {{ $attributes->merge([\'class\' => \'size-6\']) }} @class([\'text-primary\' => $active]) viewBox="0 0 24 24"><path fill="{{ $color }}" d="M0 0h24v24H0z" /></svg>'
+    const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
+
+    assert.strictEqual(wasJsx, true)
+    assert.ok(preparedSvg.includes('data-better-svg-temp-blade-0="__BLADE_BASE64__'))
+    assert.ok(preparedSvg.includes('data-better-svg-temp-blade-1="__BLADE_BASE64__'))
+    assert.ok(preparedSvg.includes('data-better-svg-temp-fill="__BLADE_BASE64__'))
+    assert.ok(!preparedSvg.includes('{{ $attributes'))
+    assert.ok(!preparedSvg.includes('@class'))
+
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
+    assert.strictEqual(final, input)
+  })
 })
 
 describe('Mixed Framework Edge Cases', () => {
-    it('should handle Vue v-bind object shorthand', () => {
-        const input = '<svg v-bind="{ id: 1, class: \'foo\' }"></svg>'
-        const options = { useCamelCase: false }
-        const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
-        
-        assert.ok(wasJsx)
-        assert.ok(preparedSvg.includes('data-better-svg-temp-v-bind'))
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
-        assert.strictEqual(final, input)
-    })
+  it('should handle Vue v-bind object shorthand', () => {
+    const input = '<svg v-bind="{ id: 1, class: \'foo\' }"></svg>'
+    const options = { useCamelCase: false }
+    const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
 
-    it('should handle Vue shorthand for events with modifiers', () => {
-        const input = '<svg @click.stop.prevent="doSth"></svg>'
-        const options = { useCamelCase: false }
-        const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
-        
-        assert.ok(wasJsx)
-        assert.ok(preparedSvg.includes('data-better-svg-temp-__AT__click__DOT__stop__DOT__prevent'))
-        
-        const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
-        assert.strictEqual(final, input)
-    })
+    assert.ok(wasJsx)
+    assert.ok(preparedSvg.includes('data-better-svg-temp-v-bind'))
+
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
+    assert.strictEqual(final, input)
+  })
+
+  it('should handle Vue shorthand for events with modifiers', () => {
+    const input = '<svg @click.stop.prevent="doSth"></svg>'
+    const options = { useCamelCase: false }
+    const { preparedSvg, wasJsx } = prepareForOptimization(input, options)
+
+    assert.ok(wasJsx)
+    assert.ok(preparedSvg.includes('data-better-svg-temp-__AT__click__DOT__stop__DOT__prevent'))
+
+    const final = finalizeAfterOptimization(preparedSvg, wasJsx, options)
+    assert.strictEqual(final, input)
+  })
 })

--- a/src/svgTransform.ts
+++ b/src/svgTransform.ts
@@ -16,6 +16,8 @@
 
 const BASE64_PREFIX = '__JSX_BASE64__'
 const BASE64_SUFFIX = '__'
+const BLADE_BASE64_PREFIX = '__BLADE_BASE64__'
+const BLADE_BASE64_SUFFIX = '__'
 
 function encodeJsx (content: string): string {
   return BASE64_PREFIX + Buffer.from(content).toString('base64') + BASE64_SUFFIX
@@ -24,6 +26,18 @@ function encodeJsx (content: string): string {
 function decodeJsx (content: string): string | null {
   if (content.startsWith(BASE64_PREFIX) && content.endsWith(BASE64_SUFFIX)) {
     const b64 = content.slice(BASE64_PREFIX.length, -BASE64_SUFFIX.length)
+    return Buffer.from(b64, 'base64').toString('utf-8')
+  }
+  return null
+}
+
+function encodeBlade (content: string): string {
+  return BLADE_BASE64_PREFIX + Buffer.from(content).toString('base64') + BLADE_BASE64_SUFFIX
+}
+
+function decodeBlade (content: string): string | null {
+  if (content.startsWith(BLADE_BASE64_PREFIX) && content.endsWith(BLADE_BASE64_SUFFIX)) {
+    const b64 = content.slice(BLADE_BASE64_PREFIX.length, -BLADE_BASE64_SUFFIX.length)
     return Buffer.from(b64, 'base64').toString('utf-8')
   }
   return null
@@ -95,11 +109,345 @@ export const svgToJsxAttributeMap: Record<string, string> = Object.fromEntries(
   Object.entries(jsxToSvgAttributeMap).map(([jsx, svg]) => [svg, jsx])
 )
 
+const BLADE_DIRECTIVE_NAMES = new Set([
+  'aware',
+  'auth',
+  'break',
+  'case',
+  'checked',
+  'class',
+  'continue',
+  'default',
+  'disabled',
+  'else',
+  'elseif',
+  'empty',
+  'endauth',
+  'endempty',
+  'endenv',
+  'enderror',
+  'endfor',
+  'endforeach',
+  'endforelse',
+  'endfragment',
+  'endguest',
+  'endif',
+  'endisset',
+  'endonce',
+  'endprepend',
+  'endproduction',
+  'endpush',
+  'endsession',
+  'endswitch',
+  'endunless',
+  'endwhile',
+  'env',
+  'error',
+  'for',
+  'foreach',
+  'forelse',
+  'fragment',
+  'guest',
+  'if',
+  'isset',
+  'once',
+  'php',
+  'prepend',
+  'production',
+  'props',
+  'push',
+  'readonly',
+  'required',
+  'selected',
+  'session',
+  'style',
+  'switch',
+  'unless',
+  'while'
+])
+
+const BLADE_DIRECTIVES_WITHOUT_PARENTHESES = new Set([
+  'auth',
+  'break',
+  'continue',
+  'default',
+  'else',
+  'endauth',
+  'endempty',
+  'endenv',
+  'enderror',
+  'endfor',
+  'endforeach',
+  'endforelse',
+  'endfragment',
+  'endguest',
+  'endif',
+  'endisset',
+  'endonce',
+  'endprepend',
+  'endproduction',
+  'endpush',
+  'endsession',
+  'endswitch',
+  'endunless',
+  'endwhile',
+  'guest',
+  'php',
+  'production'
+])
+
+function isLikelyBladeEcho (content: string): boolean {
+  const expression = content
+    .replace(/^\{\{\s*/, '')
+    .replace(/\s*\}\}$/, '')
+    .replace(/^\{!!\s*/, '')
+    .replace(/\s*!!\}$/, '')
+    .trim()
+
+  return /(?:\$|->|::|^__\s*\(|^route\s*\(|^asset\s*\(|^config\s*\(|^old\s*\(|^csrf_)/.test(expression)
+}
+
+function findBladeEchoEnd (content: string, startIdx: number): number | null {
+  if (content.startsWith('{{', startIdx)) {
+    const endIdx = content.indexOf('}}', startIdx + 2)
+    if (endIdx === -1) {
+      return null
+    }
+
+    const end = endIdx + 2
+    return isLikelyBladeEcho(content.slice(startIdx, end)) ? end : null
+  }
+
+  if (content.startsWith('{!!', startIdx)) {
+    const endIdx = content.indexOf('!!}', startIdx + 3)
+    return endIdx === -1 ? null : endIdx + 3
+  }
+
+  return null
+}
+
+function findBalancedParenthesisEnd (content: string, openIdx: number): number | null {
+  let balance = 1
+  let i = openIdx + 1
+  let inString = false
+  let stringChar = ''
+
+  while (i < content.length) {
+    const char = content[i]
+    const prevChar = content[i - 1]
+
+    if (inString) {
+      if (char === stringChar && prevChar !== '\\') {
+        inString = false
+      }
+    } else if (char === '"' || char === '\'' || char === '`') {
+      inString = true
+      stringChar = char
+    } else if (char === '(') {
+      balance++
+    } else if (char === ')') {
+      balance--
+      if (balance === 0) {
+        return i + 1
+      }
+    }
+
+    i++
+  }
+
+  return null
+}
+
+function findBladeDirectiveEnd (content: string, startIdx: number): number | null {
+  if (content[startIdx] !== '@' || content[startIdx - 1] === '@') {
+    return null
+  }
+
+  const nameMatch = /^[a-zA-Z_][a-zA-Z0-9_]*/.exec(content.slice(startIdx + 1))
+  if (!nameMatch) {
+    return null
+  }
+
+  const name = nameMatch[0]
+  if (!BLADE_DIRECTIVE_NAMES.has(name)) {
+    return null
+  }
+
+  const afterNameIdx = startIdx + 1 + name.length
+  if (content[afterNameIdx] === '(') {
+    return findBalancedParenthesisEnd(content, afterNameIdx)
+  }
+
+  if (BLADE_DIRECTIVES_WITHOUT_PARENTHESES.has(name)) {
+    return afterNameIdx
+  }
+
+  return null
+}
+
+function containsBladeSyntax (content: string): boolean {
+  for (let i = 0; i < content.length; i++) {
+    if (findBladeEchoEnd(content, i) !== null || findBladeDirectiveEnd(content, i) !== null) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function replaceBladeAttributeValues (tagContent: string): string {
+  return tagContent.replace(/([^\s=<>/]+)(\s*=\s*)(["'])([\s\S]*?)\3/g, (match, attr, equals, quote, value) => {
+    if (!containsBladeSyntax(value)) {
+      return match
+    }
+
+    return `${attr}${equals}${quote}${encodeBlade(value)}${quote}`
+  })
+}
+
+function replaceBladeStandaloneTokensInTag (
+  tagContent: string,
+  createTokenAttribute: (token: string) => string
+): string {
+  let result = ''
+  let currentIndex = 0
+  let inString = false
+  let stringChar = ''
+
+  while (currentIndex < tagContent.length) {
+    const char = tagContent[currentIndex]
+    const prevChar = tagContent[currentIndex - 1]
+
+    if (inString) {
+      result += char
+      if (char === stringChar && prevChar !== '\\') {
+        inString = false
+      }
+      currentIndex++
+      continue
+    }
+
+    if (char === '"' || char === '\'') {
+      inString = true
+      stringChar = char
+      result += char
+      currentIndex++
+      continue
+    }
+
+    const echoEnd = findBladeEchoEnd(tagContent, currentIndex)
+    if (echoEnd !== null) {
+      result += createTokenAttribute(tagContent.slice(currentIndex, echoEnd))
+      currentIndex = echoEnd
+      continue
+    }
+
+    const directiveEnd = findBladeDirectiveEnd(tagContent, currentIndex)
+    if (directiveEnd !== null) {
+      result += createTokenAttribute(tagContent.slice(currentIndex, directiveEnd))
+      currentIndex = directiveEnd
+      continue
+    }
+
+    result += char
+    currentIndex++
+  }
+
+  return result
+}
+
+function findTagEnd (content: string, startIdx: number): number | null {
+  let currentIndex = startIdx + 1
+  let inString = false
+  let stringChar = ''
+
+  while (currentIndex < content.length) {
+    const char = content[currentIndex]
+    const prevChar = content[currentIndex - 1]
+
+    if (inString) {
+      if (char === stringChar && prevChar !== '\\') {
+        inString = false
+      }
+      currentIndex++
+      continue
+    }
+
+    if (char === '"' || char === '\'') {
+      inString = true
+      stringChar = char
+      currentIndex++
+      continue
+    }
+
+    const echoEnd = findBladeEchoEnd(content, currentIndex)
+    if (echoEnd !== null) {
+      currentIndex = echoEnd
+      continue
+    }
+
+    const directiveEnd = findBladeDirectiveEnd(content, currentIndex)
+    if (directiveEnd !== null) {
+      currentIndex = directiveEnd
+      continue
+    }
+
+    if (char === '>') {
+      return currentIndex
+    }
+
+    currentIndex++
+  }
+
+  return null
+}
+
+function replaceBladeSyntaxInTags (content: string): string {
+  let result = ''
+  let currentIndex = 0
+  let bladeTokenIndex = 0
+
+  const createTokenAttribute = (token: string): string => {
+    return `data-better-svg-temp-blade-${bladeTokenIndex++}="${encodeBlade(token)}"`
+  }
+
+  while (currentIndex < content.length) {
+    const tagStartIdx = content.indexOf('<', currentIndex)
+    if (tagStartIdx === -1) {
+      result += content.slice(currentIndex)
+      break
+    }
+
+    result += content.slice(currentIndex, tagStartIdx)
+
+    const tagEndIdx = findTagEnd(content, tagStartIdx)
+    if (tagEndIdx === null) {
+      result += content.slice(tagStartIdx)
+      break
+    }
+
+    let tagContent = content.slice(tagStartIdx, tagEndIdx + 1)
+    if (!/^<[/!?]/.test(tagContent)) {
+      tagContent = replaceBladeAttributeValues(tagContent)
+      tagContent = replaceBladeStandaloneTokensInTag(tagContent, createTokenAttribute)
+    }
+
+    result += tagContent
+    currentIndex = tagEndIdx + 1
+  }
+
+  return result
+}
+
 /**
  * Detects if the SVG content contains JSX-specific syntax
  * (camelCase attributes, expression values like {2}, className, etc.)
  */
 export function isJsxSvg (svgContent: string): boolean {
+  if (containsBladeSyntax(svgContent)) {
+    return true
+  }
+
   // Check for JSX expression values like ={2} or ={variable}
   if (/=\{[^}]+\}/.test(svgContent)) {
     return true
@@ -157,10 +505,6 @@ export function isJsxSvg (svgContent: string): boolean {
 
   return false
 }
-
-
-
-
 
 /**
  * Converts JSX SVG syntax to valid SVG XML
@@ -254,16 +598,16 @@ function replaceTextInterpolations (content: string): string {
 
     // If preceded by = or not inside a tag-content area, skip
     if ((startIdx > 0 && content[startIdx - 1] === '=') || !isInsideTag) {
-        result += content.slice(currentIndex, startIdx + 1)
-        currentIndex = startIdx + 1
-        continue
+      result += content.slice(currentIndex, startIdx + 1)
+      currentIndex = startIdx + 1
+      continue
     }
 
     // Skip if it is a JSX comment start
     if (content.startsWith('/*', startIdx + 1)) {
-        result += content.slice(currentIndex, startIdx + 1)
-        currentIndex = startIdx + 1
-        continue
+      result += content.slice(currentIndex, startIdx + 1)
+      currentIndex = startIdx + 1
+      continue
     }
 
     // Append everything before "{"
@@ -282,8 +626,7 @@ function replaceTextInterpolations (content: string): string {
       if (inString) {
         if (char === stringChar && prevChar !== '\\') inString = false
       } else {
-        if (char === '"' || char === '\'' || char === '`') { inString = true; stringChar = char }
-        else if (char === '{') balance++
+        if (char === '"' || char === '\'' || char === '`') { inString = true; stringChar = char } else if (char === '{') balance++
         else if (char === '}') balance--
       }
       j++
@@ -301,9 +644,6 @@ function replaceTextInterpolations (content: string): string {
   }
   return result
 }
-
-
-
 
 function replaceJsxSpreads (content: string): string {
   let result = ''
@@ -367,7 +707,6 @@ function replaceJsxSpreads (content: string): string {
   return result
 }
 
-
 function removeJsxComments (content: string): string {
   // Remove block comments {/* ... */}
   content = content.replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
@@ -390,10 +729,10 @@ function protectEncodedAttributes (content: string): string {
     if (attr.startsWith('data-better-svg-temp-')) return match
 
     // Decide if we should protect this attribute
-    const isEncoded = value?.includes(BASE64_PREFIX)
-    const isDirective = /^(client:|v-|on:|bind:|class:|use:|let:|animate:|transition:|[:@])/.test(attr) && 
+    const isEncoded = value?.includes(BASE64_PREFIX) || value?.includes(BLADE_BASE64_PREFIX)
+    const isDirective = /^(client:|v-|on:|bind:|class:|use:|let:|animate:|transition:|[:@])/.test(attr) &&
                         !/^(xmlns|xlink|xml|sketch):/.test(attr)
-    
+
     if (!isEncoded && !isDirective) {
       return match
     }
@@ -403,7 +742,7 @@ function protectEncodedAttributes (content: string): string {
       .replace(/:/g, '__COLON__')
       .replace(/@/g, '__AT__')
       .replace(/\./g, '__DOT__')
-    
+
     if (value !== undefined) {
       return `data-better-svg-temp-${safeAttr}="${value}"`
     } else {
@@ -413,15 +752,19 @@ function protectEncodedAttributes (content: string): string {
   })
 }
 
-
 function restoreEncodedAttributes (content: string): string {
   // Restore protected attributes
   return content.replace(/data-better-svg-temp-([a-zA-Z0-9-_]+)="([^"]*)"/g, (match, safeAttr, value) => {
+    if (/^blade-\d+$/.test(safeAttr)) {
+      const decoded = decodeBlade(value)
+      return decoded ?? match
+    }
+
     const attr = safeAttr
       .replace(/__COLON__/g, ':')
       .replace(/__AT__/g, '@')
       .replace(/__DOT__/g, '.')
-    
+
     if (value === '__BOOLEAN__') {
       return attr
     }
@@ -438,6 +781,11 @@ function restoreEncodedAttributes (content: string): string {
 export function convertJsxToSvg (svgContent: string, options: OptimizationOptions = { useCamelCase: true }): string {
   // Remove JSX comments first to avoid parsing issues
   svgContent = removeJsxComments(svgContent)
+
+  // Convert Blade-only attributes/directives into temporary SVG attributes.
+  if (containsBladeSyntax(svgContent)) {
+    svgContent = replaceBladeSyntaxInTags(svgContent)
+  }
 
   // Convert JSX expression values like {2} to "2"
   svgContent = replaceJsxExpressions(svgContent)
@@ -459,7 +807,7 @@ export function convertJsxToSvg (svgContent: string, options: OptimizationOption
       svgContent = svgContent.replace(regex, `${svg}=`)
     }
   }
-  
+
   // Protect all attributes with encoded values from SVGO
   // This handles style, event handlers, and anything else that is dynamically encoded
   svgContent = protectEncodedAttributes(svgContent)
@@ -475,6 +823,20 @@ export function convertJsxToSvg (svgContent: string, options: OptimizationOption
 export function convertSvgToJsx (svgContent: string, options: OptimizationOptions = { useCamelCase: true }): string {
   // Restore protected attributes first
   svgContent = restoreEncodedAttributes(svgContent)
+
+  // Decode Blade expressions in attribute values before JSX expression decoding.
+  svgContent = svgContent.replace(/([a-zA-Z0-9-:@.]+)=(["'])(__BLADE_BASE64__[^"']*?__)\2/g, (match, attr, quote, value) => {
+    const decoded = decodeBlade(value)
+    if (decoded !== null) {
+      return `${attr}=${quote}${decoded}${quote}`
+    }
+    return match
+  })
+
+  svgContent = svgContent.replace(/__BLADE_BASE64__[A-Za-z0-9+/=]+__/g, (value) => {
+    const decoded = decodeBlade(value)
+    return decoded ?? value
+  })
 
   if (options.useCamelCase) {
     // Convert class to className
@@ -492,7 +854,7 @@ export function convertSvgToJsx (svgContent: string, options: OptimizationOption
   // Restore spread attributes
   svgContent = svgContent.replace(/\bdata-spread-\d+="([^"]*)"/g, (_match, value) => {
     const decoded = decodeJsx(value)
-    // If it wasn't encoded (legacy/fallback), try simple unescape or keep as is? 
+    // If it wasn't encoded (legacy/fallback), try simple unescape or keep as is?
     // Just handling our new logic:
     if (decoded !== null) {
       return `{...${decoded}}`
@@ -521,14 +883,13 @@ export function convertSvgToJsx (svgContent: string, options: OptimizationOption
   svgContent = svgContent.replace(/>(__JSX_BASE64__[^<]*?__)</g, (match, value) => {
     const decoded = decodeJsx(value)
     if (decoded !== null) {
-        return `>{${decoded}}<`
+      return `>{${decoded}}<`
     }
     return match
   })
 
   return svgContent
 }
-
 
 /**
  * Prepares JSX SVG content for SVGO optimization
@@ -563,4 +924,3 @@ export function finalizeAfterOptimization (optimizedSvg: string, wasJsx: boolean
 
   return optimizedSvg
 }
-


### PR DESCRIPTION
Blade files were not activating the extension, and inline SVGs with Blade syntax could break during optimization because SVGO cannot parse Blade attribute bags, directives, or echoed values directly.

This adds `.blade.php` language support and protects Blade-specific syntax before optimization, then restores it afterward so inline SVGs in Laravel views keep their original Blade expressions.

## Changes
- Register `blade` as a supported VS Code language and activation event.
- Preserve Blade attribute bags, directives, and echoed attribute values during SVG preparation/finalization.
- Document Blade support in the README.
- Add tests for Blade language registration and Blade SVG roundtrip behavior.

Closes #11